### PR TITLE
Set db username blank so it can be accessed on both our databases

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,20 +1,20 @@
 {
   "development": {
-    "username": "teresaknowles",
+    "username": "",
     "password": null,
     "database": "calorie_tracker_development",
     "host": "127.0.0.1",
     "dialect": "postgres"
   },
   "test": {
-    "username": "teresaknowles",
+    "username": "",
     "password": null,
     "database": "calorie_tracker_test",
     "host": "127.0.0.1",
     "dialect": "postgres"
   },
   "production": {
-    "username": "teresaknowles",
+    "username": "",
     "password": null,
     "database": "calorie_tracker_production",
     "host": "127.0.0.1",


### PR DESCRIPTION
Just set the config db username env to be blank to make it accessible to both of us on our local machines.

closes #23 

Co-authored-by: Teresa M Knowles <teresa07moreno@gmail.com>