### PR TITLE
Visitor can associate food item to meal

### DIFF
--- a/app.spec.js
+++ b/app.spec.js
@@ -163,4 +163,13 @@ describe('api', () => {
       })
     });
   });
+
+  describe('Associate a food item to a meal', () => {
+    test('should return a 201 status and a message', () => {
+      return request(app).post("/api/v1/meals/3/foods/3").then(response => {
+        expect(response.status).toBe(201);
+        expect(response.body.message).toBe("Successfully added Yogurt to Lunch");
+      })
+    })
+  });
 });

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -29,4 +29,20 @@ router.get("/:id/foods", function (req, res, next) {
     });
 });
 
+router.post("/:id/foods/:food_id", function (req, res, next) {
+  Meal.findByPk(req.params.id)
+    .then(meal => {
+      Food.findByPk(req.params.food_id)
+        .then(food => {
+          meal.addFood(food);
+          res.setHeader("Content-Type", "application/json");
+          res.status(201).send({message: `Successfully added ${food.name} to ${meal.name}`});
+        })
+    })
+    .catch(error => {
+      res.setHeader("Content-Type", "application/json");
+      res.status(500).send({ error })
+    });
+});
+
 module.exports = router;


### PR DESCRIPTION
This was surprisingly straightforward. Added a post route that associates a food item to a meal. I had it looking even simpler than this before I realized I needed the actual food object to interpolate its name. You can create the association with just the id though.

closes #13  